### PR TITLE
Fixed typo in Row Layout edit.js

### DIFF
--- a/src/blocks/row-layout/edit.js
+++ b/src/blocks/row-layout/edit.js
@@ -896,7 +896,7 @@ class KadenceRowLayout extends Component {
 					onChange={ bgImgSize => setAttributes( { bgImgSize } ) }
 				/>
 				<SelectControl
-					label={ __( 'Background Image Size' ) }
+					label={ __( 'Background Image Position' ) }
 					value={ bgImgPosition }
 					options={ [
 						{ value: 'center top', label: __( 'Center Top' ) },


### PR DESCRIPTION
There was a mislabeled control in the inspector settings of the Row Layout block. This PR fixes it.