### PR TITLE
button.components-button.kt-size-btn position

### DIFF
--- a/src/blocks/advanced-heading/editor.scss
+++ b/src/blocks/advanced-heading/editor.scss
@@ -27,6 +27,7 @@
     height: 18px;
     line-height: 18px;
     padding: 0 4px;
+    position: relative;
 }
 .kt-size-type-options button.components-button.kt-size-btn.is-primary, .kt-size-type-options button.components-button.kt-size-btn.is-primary:focus:not(:disabled):not([aria-disabled=true]) {
  color:#000;


### PR DESCRIPTION
In the Tabs block settings or blocks with kt-size controls, under controls such as Title Spacing, after selecting 'Linked' button, the second button 'Individual' becomes inaccessible due to positioning/z-index issue. Adding position:relative to solve the problem.